### PR TITLE
Reemit 'end' event from socket when using MCCP both locally and remote

### DIFF
--- a/src/TelnetSocket/TelnetSocket.js
+++ b/src/TelnetSocket/TelnetSocket.js
@@ -1,5 +1,6 @@
 const Stream = require('stream');
 const { optionState, q, where } = require('../constants');
+const constants = require('../constants');
 const TelnetReader = require('./TelnetReader');
 const TelnetWriter = require('./TelnetWriter');
 const options = require('../options');
@@ -37,6 +38,13 @@ class TelnetSocket extends Stream.Stream {
     this.writer.pipe(this.socket);
 
     expose(this.socket, 'setEncoding', this);
+
+    if (
+      this.remoteOptions.has(constants.options.MCCP) &&
+      this.localOptions.has(constants.options.MCCP)
+    ) {
+      reemit(this.socket, 'end', this);
+    }
 
     expose(this.writer, 'write', this);
     expose(this.writer, 'end', this);


### PR DESCRIPTION
The event 'end' is never emitted when listening from a client, using MCCP on remote and local.
This is a bit hacky, but I didn't find any other solution.
Should have been done in MCCP.js, but didn't find any good way.
I don't really know what the real problem is, could be the stream is in the
middle of expecting to decompress when it receives an 'end', and it will be ignored?

Test code:

```js
const telnetlib = require("telnetlib");

const { MCCP } = telnetlib.options;

const c = telnetlib
  .createConnection(
    {
      host: "aardwolf.org",
      port: 23,
      remoteOptions: [MCCP],
      localOptions: [MCCP],
    },
    () => {
      setTimeout(() => {
        c.write("olooorin\n");
        setTimeout(() => {
          c.write("wrongpasswordforcelinkclose\n");
        }, 1000);
      }, 1000);
    }
  )
  .on("end", () => {
    console.log("END!");
  });
```