### PR TITLE
Feature/gmcp ansi

### DIFF
--- a/src/Options/GMCP.js
+++ b/src/Options/GMCP.js
@@ -6,17 +6,21 @@ class GMCP extends TelnetOption {
   }
 
   subnegotiation(buffer) {
-    let [, name, data] = buffer
-      .toString()
-      .match(/([a-z_][\w-_]*(?:\.[a-z_][\w-_]*)+)\s*(.*)?/i);
-    name = name.toLowerCase();
-    let [, packageName, messageName] = name.match(/(.*)\.(.*)/);
+    try {
+      let [, name, data] = buffer
+        .toString()
+        .match(/([a-z_][\w-_]*(?:\.[a-z_][\w-_]*)+)\s*(.*)?/i);
+      name = name.toLowerCase();
+      let [, packageName, messageName] = name.match(/(.*)\.(.*)/);
 
-    if (data) {
-      data = JSON.parse(data);
+      if (data) {
+        data = JSON.parse(data);
+      }
+      this.emit(`gmcp/${name}`, data);
+      this.emit('gmcp', packageName, messageName, data);
+    } catch (err) {
+      this.emit('error', err);
     }
-    this.emit(`gmcp/${name}`, data);
-    this.emit('gmcp', packageName, messageName, data);
   }
 
   send(packageName, messageName, data) {

--- a/src/Options/GMCP.js
+++ b/src/Options/GMCP.js
@@ -14,7 +14,7 @@ class GMCP extends TelnetOption {
       let [, packageName, messageName] = name.match(/(.*)\.(.*)/);
 
       if (data) {
-        data = JSON.parse(data);
+        data = JSON.parse(data.replace(/\x1b/g, '\\u001b'));
       }
       this.emit(`gmcp/${name}`, data);
       this.emit('gmcp', packageName, messageName, data);


### PR DESCRIPTION
Add support for ANSI in GMCP messages.
Some servers - looking at you aardwolf - will include the ESC char directly in the JSON.
This makes the JSON invalid. This fix replaces the ESC sequence with escaped string char.
ANSI should come out correct.

+ emit errors.